### PR TITLE
add bool to check whether a scheduler is started

### DIFF
--- a/aioscheduler/scheduler.py
+++ b/aioscheduler/scheduler.py
@@ -63,12 +63,13 @@ class TimedScheduler:
             self._datetime_func = datetime.utcnow
         else:
             self._datetime_func = datetime.now
-        # Indicator if the scheduler is running
-        self._started: bool = False
+
+    @property
+    def is_started(self) -> bool:
+        return bool(self._task)
 
     def start(self) -> None:
         self._task = asyncio.create_task(self.loop())
-        self._started = True
 
     async def loop(self) -> None:
         while True:
@@ -177,12 +178,13 @@ class QueuedScheduler:
         self._cancelled: Set[UUID] = set()
         # Maximum tasks to schedule
         self._max_tasks = max_tasks
-        # Indicator if the scheduler is running
-        self._started: bool = False
+
+    @property
+    def is_started(self) -> bool:
+        return bool(self._task)
 
     def start(self) -> None:
         self._task = asyncio.create_task(self.loop())
-        self._started = True
 
     async def loop(self) -> None:
         while True:

--- a/aioscheduler/scheduler.py
+++ b/aioscheduler/scheduler.py
@@ -66,7 +66,7 @@ class TimedScheduler:
 
     @property
     def is_started(self) -> bool:
-        return bool(self._task)
+        return self._task is not None and not self._task.done()
 
     def start(self) -> None:
         self._task = asyncio.create_task(self.loop())
@@ -181,7 +181,7 @@ class QueuedScheduler:
 
     @property
     def is_started(self) -> bool:
-        return bool(self._task)
+        return self._task is not None and not self._task.done()
 
     def start(self) -> None:
         self._task = asyncio.create_task(self.loop())

--- a/aioscheduler/scheduler.py
+++ b/aioscheduler/scheduler.py
@@ -63,9 +63,12 @@ class TimedScheduler:
             self._datetime_func = datetime.utcnow
         else:
             self._datetime_func = datetime.now
+        # Indicator if the scheduler is running
+        self._started: bool = False
 
     def start(self) -> None:
         self._task = asyncio.create_task(self.loop())
+        self._started = True
 
     async def loop(self) -> None:
         while True:
@@ -174,9 +177,12 @@ class QueuedScheduler:
         self._cancelled: Set[UUID] = set()
         # Maximum tasks to schedule
         self._max_tasks = max_tasks
+        # Indicator if the scheduler is running
+        self._started: bool = False
 
     def start(self) -> None:
         self._task = asyncio.create_task(self.loop())
+        self._started = True
 
     async def loop(self) -> None:
         while True:


### PR DESCRIPTION
this allows users to directly check whether a scheduler is running via `TimedScheduler._started` or `QueuedScheduler._started`  
could prove useful for debugging purposes