### PR TITLE
support python 3.11

### DIFF
--- a/aioscheduler/__init__.py
+++ b/aioscheduler/__init__.py
@@ -29,7 +29,7 @@ from .scheduler import (  # noqa: F401
 )
 
 __title__ = "aioscheduler"
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 __author__ = "Jens Reidel"
 __license__ = "MIT"
 __copyright__ = "Copyright 2020 (c) Jens Reidel"

--- a/aioscheduler/scheduler.py
+++ b/aioscheduler/scheduler.py
@@ -83,10 +83,10 @@ class TimedScheduler:
             # Sleep until task will be executed
             done, _ = await asyncio.wait(
                 [
-                    asyncio.sleep(
+                    asyncio.create_task(asyncio.sleep(
                         (next_.priority - self._datetime_func()).total_seconds()
-                    ),
-                    self._restart.wait(),
+                    )),
+                    asyncio.create_task(self._restart.wait()),
                 ],
                 return_when=asyncio.FIRST_COMPLETED,
             )

--- a/aioscheduler/scheduler.py
+++ b/aioscheduler/scheduler.py
@@ -81,7 +81,7 @@ class TimedScheduler:
                 next_.priority, datetime
             )  # mypy fix
             # Sleep until task will be executed
-            done, _ = await asyncio.wait(
+            done, pending = await asyncio.wait(
                 [
                     asyncio.create_task(asyncio.sleep(
                         (next_.priority - self._datetime_func()).total_seconds()
@@ -90,6 +90,8 @@ class TimedScheduler:
                 ],
                 return_when=asyncio.FIRST_COMPLETED,
             )
+            for task in pending:
+                task.cancel()
             fut = done.pop()
             if fut.result() is True:  # restart event
                 continue

--- a/tests/timed_scheduler_cancel.py
+++ b/tests/timed_scheduler_cancel.py
@@ -9,7 +9,7 @@ from aioscheduler import TimedScheduler
 
 
 async def work(n: int) -> None:
-    await asyncio.sleep(10)
+    await asyncio.sleep(60)
     print(f"I am doing heavy work: {n}")
 
 
@@ -19,7 +19,7 @@ async def main() -> None:
     scheduler.start()
     tasks = []
 
-    for i in range(10):
+    for i in range(50):
         tasks.append(
             scheduler.schedule(work(i), starting_time + timedelta(seconds=5 + i))
         )
@@ -33,7 +33,7 @@ async def main() -> None:
     print(scheduler.cancel(tasks[-1]))
     print(len(scheduler._running))
     print(len(scheduler._tasks))
-    await asyncio.sleep(20)
+    await asyncio.sleep(5)
 
 
 asyncio.run(main())

--- a/tests/timed_scheduler_cancel.py
+++ b/tests/timed_scheduler_cancel.py
@@ -9,7 +9,7 @@ from aioscheduler import TimedScheduler
 
 
 async def work(n: int) -> None:
-    await asyncio.sleep(60)
+    await asyncio.sleep(10)
     print(f"I am doing heavy work: {n}")
 
 
@@ -19,7 +19,7 @@ async def main() -> None:
     scheduler.start()
     tasks = []
 
-    for i in range(50):
+    for i in range(10):
         tasks.append(
             scheduler.schedule(work(i), starting_time + timedelta(seconds=5 + i))
         )
@@ -33,7 +33,7 @@ async def main() -> None:
     print(scheduler.cancel(tasks[-1]))
     print(len(scheduler._running))
     print(len(scheduler._tasks))
-    await asyncio.sleep(5)
+    await asyncio.sleep(20)
 
 
 asyncio.run(main())


### PR DESCRIPTION
closes #3

in python 3.11, `asyncio.wait()` cannot be passed coroutines, only tasks, which breaks this code

https://github.com/Gelbpunkt/aioscheduler/blob/8bb46be71894c022ce4862212c39636c5789a181/aioscheduler/scheduler.py#L84C8-L92

My fix just wraps the coros in tasks and it works just fine

ignore the changes in `timed_scheduler_cancel.py`, I was making sure the fix worked